### PR TITLE
Remove subjects backup from sync script

### DIFF
--- a/image-update/strimzi-image-update.sh
+++ b/image-update/strimzi-image-update.sh
@@ -82,7 +82,6 @@ do
 
     if test -f "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE"; then
         export METADATA=$(yq e '.metadata' "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE")
-        export SUBJECTS=$(yq e '.subjects' "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE")
     else
       echo "File $TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE does not exists. Skipping metadata backup."
     fi
@@ -91,9 +90,6 @@ do
 
     if test -f "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE"; then
         yq e -i '.metadata = env(METADATA)' "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE"
-        if [[ $SUBJECTS != null ]]; then
-            yq e -i '.subjects = env(SUBJECTS)' "$TARGET_DIR/$YAML_BUNDLE_PATH/$C_FILE"
-        fi
     fi
 done
 


### PR DESCRIPTION
Subject should be synced manully -> create our own bindings and change the names of it a little bit to be sure, that data will be kept